### PR TITLE
Add optional docking support for ImCoolBar

### DIFF
--- a/ImCoolBar.cpp
+++ b/ImCoolBar.cpp
@@ -31,6 +31,18 @@ SOFTWARE.
 #include <vector>
 #include <array>
 
+#ifndef IMCOOLBAR_HAS_DOCKING
+#if defined(IMGUI_HAS_DOCK)
+#define IMCOOLBAR_HAS_DOCKING
+#endif
+#endif
+
+#ifdef IMCOOLBAR_HAS_DOCKING
+#define ICB_DOCKING_HOST_FLAGS (ImGuiWindowFlags_DockNodeHost | ImGuiWindowFlags_NoDocking)
+#else
+#define ICB_DOCKING_HOST_FLAGS 0
+#endif
+
 #define ICB_PREFIX "ICB"
 //#define ENABLE_IMCOOLBAR_DEBUG
 
@@ -92,8 +104,7 @@ IMGUI_API bool ImGui::BeginCoolBar(const char* vLabel, ImCoolBarFlags vCBFlags, 
         ImGuiWindowFlags_NoBackground |        //
 #endif                                         //
         ImGuiWindowFlags_NoFocusOnAppearing |  //
-        ImGuiWindowFlags_DockNodeHost |        //
-        ImGuiWindowFlags_NoDocking;            //
+        ICB_DOCKING_HOST_FLAGS;                //
     bool res = ImGui::Begin(vLabel, nullptr, flags);
     if (!res) {
         ImGui::End();

--- a/ImCoolBar.h
+++ b/ImCoolBar.h
@@ -26,6 +26,10 @@ SOFTWARE.
 
 #include "imgui.h"
 
+#if !defined(IMCOOLBAR_HAS_DOCKING) && defined(IMGUI_HAS_DOCK)
+#define IMCOOLBAR_HAS_DOCKING
+#endif
+
 typedef int ImCoolBarFlags;                //
 enum ImCoolBarFlags_ {                     //
     ImCoolBarFlags_None       = 0,         //

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 # ImCoolbar
 
+## Docking support
+
+Works with Dear ImGui 1.92 on both the docking and non-docking branches. Docking
+window flags are enabled automatically when `IMGUI_HAS_DOCK` is defined, or by
+defining `IMCOOLBAR_HAS_DOCKING` before including `ImCoolBar.h`.
+
 # Minimal Sample
 
 ```cpp


### PR DESCRIPTION
## Summary
- Detect ImGui docking branch and expose `IMCOOLBAR_HAS_DOCKING`
- Use new macro to include docking window flags only when available
- Document docking configuration and ImGui 1.92 support

## Testing
- `g++ -std=c++17 -I/tmp/imgui -c ImCoolBar.cpp -o /tmp/ImCoolBar.o`
- `g++ -std=c++17 -I/tmp/imgui_dock -c ImCoolBar.cpp -o /tmp/ImCoolBar_dock.o`


------
https://chatgpt.com/codex/tasks/task_e_68b5f9db5138832cb3135da92e78dfeb