### PR TITLE
docs: mention fork origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # ImCoolbar
 
+This repository is a fork of the original [aiekick/ImCoolBar](https://github.com/aiekick/ImCoolBar).
+
 ## Docking support
 
 Works with Dear ImGui 1.92 on both the docking and non-docking branches. Docking


### PR DESCRIPTION
## Summary
- clarify in README that this repository is a fork of [aiekick/ImCoolBar](https://github.com/aiekick/ImCoolBar)

## Testing
- `cmake -S . -B build` *(fails: missing dependency imgui.h when building)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fde9cb68832cb316290d7896afc5