### PR TITLE
Simplify ImCoolBarConfig field names

### DIFF
--- a/ImCoolBar.h
+++ b/ImCoolBar.h
@@ -43,36 +43,36 @@ struct ImCoolBarConfig {
     float hovered_size               = 60.0f;                 //
     float anim_step                  = 0.15f;                 //
     float effect_strength            = 0.5f;                  //
-    float mouse_ema_half_life_ms     = 50.0f;                 // <=0 disables time-based EMA
-    float anim_ema_half_life_ms      = 50.0f;                 // <=0 uses step-based anim_step
-    bool pixel_snap_window           = true;                  // snap window pos to integer pixels
-    bool pixel_snap_items            = false;                 // snap inner offsets (buttons)
-	bool enable_local_aa             = true;                  // локально включить AA для бара
-    float rounding_override          = -1.0f;                 // <0 = не трогать, >=0 = PushStyleVar(FrameRounding, value)
+    float mouse_smoothing_ms         = 50.0f;                 // <=0 disables time-based smoothing (EMA half-life)
+    float anim_smoothing_ms          = 50.0f;                 // <=0 uses step-based anim_step (EMA half-life)
+    bool snap_window_to_pixels       = true;                  // snap window pos to integer pixels
+    bool snap_items_to_pixels        = false;                 // snap inner offsets (buttons)
+    bool local_antialiasing          = true;                  // локально включить AA для бара
+    float frame_rounding_override    = -1.0f;                 // <0 = не трогать, >=0 = PushStyleVar(FrameRounding, value)
     ImCoolBarConfig(                                          //
         const ImVec2 vAnchor         = ImVec2(-1.0f, -1.0f),  //
         const float  vNormalSize     = 40.0f,                 //
         const float  vHoveredSize    = 60.0f,                 //
         const float  vAnimStep       = 0.15f,                 //
         const float  vEffectStrength = 0.5f,                  //
-        const float  vMouseEmaHalfLifeMs = 50.0f,             //
-        const float  vAnimEmaHalfLifeMs = 50.0f,              //
-        const bool   vPixelSnapWindow = true,                 //
-        const bool   vPixelSnapItems = false,
-		const bool   vEnableLocalAA = true,
-		const float  vRoundingOverride = 50.0f)               //
+        const float  vMouseSmoothingMs      = 50.0f,          //
+        const float  vAnimSmoothingMs       = 50.0f,          //
+        const bool   vSnapWindowToPixels    = true,           //
+        const bool   vSnapItemsToPixels     = false,
+        const bool   vLocalAntialiasing     = true,
+        const float  vFrameRoundingOverride = 50.0f)          //
         :                                                     //
           anchor(vAnchor),                                    //
           normal_size(vNormalSize),                           //
           hovered_size(vHoveredSize),                         //
           anim_step(vAnimStep),                               //
           effect_strength(vEffectStrength),                   //
-          mouse_ema_half_life_ms(vMouseEmaHalfLifeMs),        //
-          anim_ema_half_life_ms(vAnimEmaHalfLifeMs),          //
-          pixel_snap_window(vPixelSnapWindow),                //
-          pixel_snap_items(vPixelSnapItems),
-		  enable_local_aa(vEnableLocalAA),
-		  rounding_override(vRoundingOverride)
+          mouse_smoothing_ms(vMouseSmoothingMs),              //
+          anim_smoothing_ms(vAnimSmoothingMs),                //
+          snap_window_to_pixels(vSnapWindowToPixels),         //
+          snap_items_to_pixels(vSnapItemsToPixels),
+          local_antialiasing(vLocalAntialiasing),             //
+          frame_rounding_override(vFrameRoundingOverride)
     {
     }
 };


### PR DESCRIPTION
## Summary
- Rename ImCoolBarConfig fields to shorter, user-friendly names
- Clarify smoothing uses EMA and expose simpler snapping/AA controls

## Testing
- `cmake -S . -B build` (passes)
- `cmake --build build` (fails: imgui.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68b704acb88c832ca772e5cd8cf8e90a