### PR TITLE
Add 2025 NewYaroslav copyright

### DIFF
--- a/ImCoolBar.cpp
+++ b/ImCoolBar.cpp
@@ -2,6 +2,7 @@
 MIT License
 
 Copyright (c) 2023 Stephane Cuillerdier (aka Aiekick)
+Copyright (c) 2025 NewYaroslav
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ImCoolBar.h
+++ b/ImCoolBar.h
@@ -2,6 +2,7 @@
 MIT License
 
 Copyright (c) 2024 Stephane Cuillerdier (aka Aiekick)
+Copyright (c) 2025 NewYaroslav
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2023 Aiekick
+Copyright (c) 2025 NewYaroslav
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- add NewYaroslav 2025 copyright notice in license and source headers

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: imgui.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b71653aeac832c89ad8daa935f6f17