### PR TITLE
docs: note default smoothing and antialiasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ImCoolBar
 
 This repository is a fork of the original [aiekick/ImCoolBar](https://github.com/aiekick/ImCoolBar).
-It keeps the original API spirit while fixing hover glitches and adding optional smoothing and antialiasing controls.
+It keeps the original API spirit while fixing hover glitches and enabling smoothing and antialiasing by default (configurable).
 
 ---
 
@@ -19,18 +19,19 @@ It keeps the original API spirit while fixing hover glitches and adding optional
 
 **Smoothing (time‑based EMA)**
 
+* Enabled by default with a 50 ms half‑life; set to `0` to disable.
 * Mouse coordinate filtering with half‑life in milliseconds; frame‑rate invariant.
 * `anim_scale` smoothing to targets 0/1 with its own half‑life; fallback to the old step‑based `anim_step` when disabled.
 
-**Antialiasing (optional)**
+**Antialiasing (on by default)**
 
-* Local AA for this bar’s draw list (`AntiAliasedFill|Lines`) can be enabled via config.
+* Local AA for this bar’s draw list (`AntiAliasedFill|Lines`) is enabled by default but can be disabled via config.
 * Optional local `FrameRounding` override for smoother visuals.
 * Draw‑list flags and style are restored in `EndCoolBar()`.
 
 **Pixel snapping (optional)**
 
-* Separate snapping controls for window position and inner item offsets to avoid visible “stepping”.
+* Separate snapping controls for window position and inner item offsets to avoid visible “stepping” (both enabled by default).
 
 **Metrics**
 
@@ -78,13 +79,13 @@ auto coolbar_button = [](const char* label) -> bool {
     return ImGui::Button(label, ImVec2(w, w));
 };
 
-ImCoolBarConfig cfg;                     // defaults
+ImCoolBarConfig cfg;                     // defaults (50 ms smoothing, AA & pixel snapping on)
 cfg.anchor                 = ImVec2(0.5f, 1.0f); // bottom-center of the viewport
 cfg.mouse_smoothing_ms     = 120.0f;           // time-based mouse smoothing (0 = off)
 cfg.anim_smoothing_ms      = 120.0f;           // time-based anim smoothing (0 = step mode)
-cfg.local_antialiasing     = true;             // local AA just for this bar
+cfg.local_antialiasing     = true;             // local AA just for this bar (default true)
 cfg.frame_rounding_override = 6.0f;            // optional per-bar rounding
-cfg.snap_window_to_pixels  = true;             // snap window to whole pixels (for crisp text)
+cfg.snap_window_to_pixels  = true;             // snap window to whole pixels (default)
 cfg.snap_items_to_pixels   = false;            // allow subpixel item offsets
 
 if (ImGui::BeginCoolBar("##CoolBarMain", ImCoolBarFlags_Horizontal, cfg)) {
@@ -106,10 +107,10 @@ if (ImGui::BeginCoolBar("##CoolBarMain", ImCoolBarFlags_Horizontal, cfg)) {
 
 ```cpp
 // Shared smoothing/visuals
-ImCoolBarConfig common;
+ImCoolBarConfig common;                     // defaults (50 ms smoothing, AA & pixel snapping on)
 common.mouse_smoothing_ms      = 100.0f;
 common.anim_smoothing_ms       = 120.0f;
-common.local_antialiasing      = true;
+common.local_antialiasing      = true;      // default true
 common.frame_rounding_override = 6.0f;
 
 // Bottom horizontal bar
@@ -167,15 +168,16 @@ IMGUI_API void  ShowCoolBarMetrics(bool* opened);
 | `hovered_size`           | `float`  |    `60.0` | Max size when fully hovered.                                         |
 | `anim_step`              | `float`  |    `0.15` | Legacy step per frame for `anim_scale` (used when EMA disabled).     |
 | `effect_strength`        | `float`  |     `0.5` | Strength parameter for hover influence curve.                        |
-| `mouse_smoothing_ms` | `float`  |     `0.0` | EMA half‑life for mouse filtering; `<=0` disables.                   |
-| `anim_smoothing_ms`  | `float`  |     `0.0` | EMA half‑life for `anim_scale`; `<=0` uses `anim_step`.              |
-| `local_antialiasing`        | `bool`   |   `false` | Enable AA on this bar’s draw list only.                              |
+| `mouse_smoothing_ms` | `float`  |    `50.0` | EMA half‑life for mouse filtering; `<=0` disables.                   |
+| `anim_smoothing_ms`  | `float`  |    `50.0` | EMA half‑life for `anim_scale`; `<=0` uses `anim_step`.              |
+| `local_antialiasing`        | `bool`   |    `true` | Enable AA on this bar’s draw list only (default on).                 |
 | `frame_rounding_override`      | `float`  |    `-1.0` | `<0` keep global; `>=0` push per‑bar `FrameRounding`.                |
 | `snap_window_to_pixels`      | `bool`   |    `true` | Snap window position to whole pixels (crisp text).                   |
-| `snap_items_to_pixels`       | `bool`   |   `false` | Snap inner item offsets; turn **off** for subpixel smoothness.       |
+| `snap_items_to_pixels`       | `bool`   |    `true` | Snap inner item offsets; turn **off** for subpixel smoothness.       |
 
 **Notes**
 
+* Mouse/anim smoothing (50 ms half‑life) and local antialiasing are enabled by default; set smoothing to `0` or antialiasing to `false` to disable.
 * EMA alpha per frame: `α = 1 - exp(-ln(2) * dt_ms / half_life_ms)`.
 * Subpixel movement is visually smoother with AA and non‑zero rounding.
 


### PR DESCRIPTION
## Summary
- document that smoothing (50 ms) and local antialiasing are enabled by default
- update configuration table defaults including pixel snapping settings

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: imgui.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be75e9bae8832c80897a6e36b37053