### PR TITLE
docs: update README examples for new config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ auto coolbar_button = [](const char* label) -> bool {
 };
 
 ImCoolBarConfig cfg;                     // defaults (50 ms smoothing, AA & pixel snapping on)
-cfg.anchor                 = ImVec2(0.5f, 1.0f); // bottom-center of the viewport
-cfg.mouse_smoothing_ms     = 120.0f;           // time-based mouse smoothing (0 = off)
-cfg.anim_smoothing_ms      = 120.0f;           // time-based anim smoothing (0 = step mode)
-cfg.local_antialiasing     = true;             // local AA just for this bar (default true)
-cfg.frame_rounding_override = 6.0f;            // optional per-bar rounding
-cfg.snap_window_to_pixels  = true;             // snap window to whole pixels (default)
-cfg.snap_items_to_pixels   = false;            // allow subpixel item offsets
+cfg.anchor                  = ImVec2(0.5f, 1.0f); // bottom-center of the viewport
+cfg.mouse_smoothing_ms      = 120.0f;           // time-based mouse smoothing (default 50, 0 = off)
+cfg.anim_smoothing_ms       = 120.0f;           // time-based anim smoothing (default 50, 0 = step mode)
+cfg.local_antialiasing      = true;             // local AA just for this bar (default true)
+cfg.frame_rounding_override = 6.0f;             // optional per-bar rounding
+cfg.snap_window_to_pixels   = true;             // snap window to whole pixels (default true)
+cfg.snap_items_to_pixels    = true;             // snap inner item offsets to whole pixels (default true)
 
 if (ImGui::BeginCoolBar("##CoolBarMain", ImCoolBarFlags_Horizontal, cfg)) {
     const char* labels = "ABCDEFGHIJKL";
@@ -112,6 +112,8 @@ common.mouse_smoothing_ms      = 100.0f;
 common.anim_smoothing_ms       = 120.0f;
 common.local_antialiasing      = true;      // default true
 common.frame_rounding_override = 6.0f;
+common.snap_window_to_pixels   = true;      // default true
+common.snap_items_to_pixels    = true;      // default true
 
 // Bottom horizontal bar
 {


### PR DESCRIPTION
## Summary
- update README examples with current `ImCoolBarConfig` field names and defaults
- document pixel snapping defaults in multi-bar and minimal samples

## Testing
- `g++ -std=c++17 -I/workspace/imgui -I/workspace/ImCoolBar -c /tmp/snippets_test.cpp`
- `g++ -std=c++17 -I/workspace/imgui -I/workspace/ImCoolBar -c ImCoolBar.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68be77b274b0832cbb16e8ba1de8d30d